### PR TITLE
added feedbin url

### DIFF
--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -31,7 +31,7 @@
                 </a>
             </li>
             <li id="feedbin">
-                <a href="https://www.newsblur.com/?url=" data-action="subscribe">
+                <a href="https://feedbin.com/?subscribe=" data-action="subscribe">
                     <img src="../icons/feedbin.svg" alt="Feedbin Icon" />
                     Feedbin
                 </a>


### PR DESCRIPTION
Thanks for making this! 

I tried it out and it looks like the Feedbin button had the Newsmast link in it, so I added `https://feedbin.com/?subscribe=` from [this page](https://feedbin.com/help/how-to-subscribe/) to the field. That's the only change I made.